### PR TITLE
Include sp module address in the ScheduledPaymentModuleSetup event

### DIFF
--- a/contracts/ScheduledPaymentModule.sol
+++ b/contracts/ScheduledPaymentModule.sol
@@ -20,7 +20,8 @@ contract ScheduledPaymentModule is Module {
         address indexed avatar,
         address target,
         address config,
-        address exchange
+        address exchange,
+        address moduleAddress
     );
     event PaymentScheduled(bytes32 spHash);
     event ScheduledPaymentCancelled(bytes32 spHash);
@@ -107,7 +108,8 @@ contract ScheduledPaymentModule is Module {
             _avatar,
             _target,
             _config,
-            _exchange
+            _exchange,
+            address(this)
         );
     }
 

--- a/test/ScheduledPayment.spec.ts
+++ b/test/ScheduledPayment.spec.ts
@@ -160,7 +160,8 @@ describe("ScheduledPaymentModule", async () => {
           avatar.address,
           avatar.address,
           AddressZero,
-          AddressZero
+          AddressZero,
+          scheduledPaymentModule.address
         );
     });
   });


### PR DESCRIPTION
This adds the scheduled payment module contract address to the `ScheduledPaymentModuleSetup` event. We need this because we want to index this event using the subgraph with the following data: owner, safe address, module address. 