### PR TITLE
Fix test fail after midnight

### DIFF
--- a/test/ScheduledPayment.spec.ts
+++ b/test/ScheduledPayment.spec.ts
@@ -1359,12 +1359,15 @@ describe("ScheduledPaymentModule", async () => {
             const feeReceiver = await config.feeReceiver();
             const untiLastValidDays = moment
               .unix(until)
+              .utc(true)
               .add(validForDays, "days")
               .unix();
             let month = 1;
             let _validExecutionTimestamp = moment
               .unix(validExecutionTimestamp.unix())
+              .utc(true)
               .add(validDay, "days");
+
             do {
               await setNextBlockTimestamp(_validExecutionTimestamp.unix());
 


### PR DESCRIPTION
Ticket: CS-4925

The root cause of this issue is the valid recurring time is impacted by DST and EST conversion. So I updated the test to ensure the valid recurring time is always in UTC.