### PR TITLE
Don't call exchange contract if gas token already in USD

### DIFF
--- a/contracts/ScheduledPaymentModule.sol
+++ b/contracts/ScheduledPaymentModule.sol
@@ -573,11 +573,19 @@ contract ScheduledPaymentModule is Module {
         returns (uint256)
     {
         if (fee.fixedUSD.value == 0) return 0;
-        Decimal.D256 memory usdRate = IExchange(exchange).exchangeRateOf(token);
 
-        require(usdRate.value > 0, "exchange rate cannot be 0");
-        uint8 tokenDecimals = ERC20(token).decimals();
+        uint8 tokenDecimals;
         uint256 ten = 10;
+        address usdToken = IExchange(exchange).usdToken();
+        if (usdToken == token) {
+            tokenDecimals = ERC20(usdToken).decimals();
+            return Decimal.mul(ten**tokenDecimals, fee.fixedUSD);
+        }
+
+        Decimal.D256 memory usdRate = IExchange(exchange).exchangeRateOf(token);
+        require(usdRate.value > 0, "exchange rate cannot be 0");
+        tokenDecimals = ERC20(token).decimals();
+
         return
             Decimal.div(Decimal.mul(ten**tokenDecimals, fee.fixedUSD), usdRate);
     }

--- a/contracts/interfaces/IExchange.sol
+++ b/contracts/interfaces/IExchange.sol
@@ -7,4 +7,6 @@ interface IExchange {
     function exchangeRateOf(address token)
         external
         returns (Decimal.D256 memory);
+
+    function usdToken() external view returns (address);
 }

--- a/contracts/test/TestExchange.sol
+++ b/contracts/test/TestExchange.sol
@@ -4,17 +4,20 @@ pragma solidity >=0.8.0;
 import "../interfaces/IExchange.sol";
 
 contract TestExchange is IExchange {
+    address public usdToken;
     Decimal.D256 public price;
 
-    constructor(uint256 _price) {
+    constructor(uint256 _price, address _usdToken) {
         price.value = _price;
+        usdToken = _usdToken;
     }
 
-    function exchangeRateOf(address)
+    function exchangeRateOf(address token)
         external
         view
         returns (Decimal.D256 memory)
     {
+        require(token != usdToken, "cannot find the pool");
         return price;
     }
 }


### PR DESCRIPTION
**Problem**
In the previous implementation, every time executed the scheduled payment the module will try to get the USD rate of the token, It will be an issue if the gas token is already in USD. Because there's no pair of the same token (i.e. USDC/USDC) in Uniswap.

**Solution**
I added one step to check whether the gas token is a USD token or not. If yes, then the module doesn't need to get the USD rate.
